### PR TITLE
Update vocab_utils.py

### DIFF
--- a/src/vocab_utils.py
+++ b/src/vocab_utils.py
@@ -130,7 +130,7 @@ class Vocab(object):
                 word = ' '
                 parts = [' '] + line.strip().split(' ')
             else:
-                parts = line.split(' ')
+                parts = line.rstrip().split(' ')
                 word = parts[0]
             self.word_dim = len(parts[1:])
             if (voc is not None) and (word not in voc): continue


### PR DESCRIPTION
Without calling rstrip(), the \n character is its own token, which causes numpy to raise a ValueError when it tries to cast that into a float32